### PR TITLE
TLS support for on-machine keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ hs_err_pid*
 .settings/*
 target/*
 build/*
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.brooklyn.etcd</groupId>
     <artifactId>brooklyn-etcd</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Brooklyn Etcd Entities</name>
     <description>

--- a/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
+++ b/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
@@ -207,7 +207,9 @@ public class EtcdClusterImpl extends DynamicClusterImpl implements EtcdCluster {
     }
 
     private String getNodeAddress(Entity node) {
-        return "http://" + node.sensors().get(Attributes.SUBNET_ADDRESS) + ":" + node.sensors().get(EtcdNode.ETCD_PEER_PORT);
+        // TODO Implement EtcdNode.ADVERTISE_PEER_URLS sensor + config on the node instead
+        boolean isSecure = Boolean.TRUE.equals(node.config().get(EtcdNode.SECURE_PEER));
+        return "http" + (isSecure ? "s" : "") + "://" + node.sensors().get(Attributes.SUBNET_ADDRESS) + ":" + node.sensors().get(EtcdNode.ETCD_PEER_PORT);
     }
 
     public static class MemberTrackingPolicy extends AbstractMembershipTrackingPolicy {

--- a/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdNode.java
+++ b/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdNode.java
@@ -15,6 +15,8 @@
  */
 package io.brooklyn.entity.nosql.etcd;
 
+import java.util.Collection;
+
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.ImplementedBy;
@@ -27,12 +29,13 @@ import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
-import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.time.Duration;
+
+import com.google.common.reflect.TypeToken;
 
 @Catalog(name="Etcd Node")
 @ImplementedBy(EtcdNodeImpl.class)
@@ -56,6 +59,17 @@ public interface EtcdNode extends SoftwareProcess {
 
     @SetFromFlag("etcdPeerPort")
     PortAttributeSensorAndConfigKey ETCD_PEER_PORT = ConfigKeys.newPortSensorAndConfigKey("etcd.peer.port", "Etcd peer port", PortRanges.fromInteger(2380));
+
+    /** @since 2.1.0 */
+    @SetFromFlag("etcdAdditionalOptions")
+    ConfigKey<String> ADDITIONAL_OPTIONS = ConfigKeys.newStringConfigKey("etcd.options.additional", "Additional options to pass to the etcd binary");
+
+    /** @since 2.1.0 */
+    @SetFromFlag("etcdSecureClient")
+    ConfigKey<Boolean> SECURE_PEER = ConfigKeys.newBooleanConfigKey("etcd.peer.secure");
+    /** @since 2.1.0 */
+    @SetFromFlag("etcdSecurePeer")
+    ConfigKey<Boolean> SECURE_CLIENT = ConfigKeys.newBooleanConfigKey("etcd.client.secure");
 
     @SetFromFlag("nodeName")
     AttributeSensorAndConfigKey<String, String> ETCD_NODE_NAME = ConfigKeys.newStringSensorAndConfigKey(


### PR DESCRIPTION
Adds the following config keys, allowing the configuration of TLS with on-machine keys:
- `etcd.peer.secure`
- `etcd.client.secure`
- `etcd.options.additional`
