### PR TITLE
Etcd clustered

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -30,6 +30,7 @@ brooklyn.catalog:
     itemType: entity
     item:
       type: io.brooklyn.entity.nosql.etcd.EtcdNode
+      id: etcd-node
 
       brooklyn.enrichers:
         - type: org.apache.brooklyn.enricher.stock.Transformer

--- a/catalog.bom
+++ b/catalog.bom
@@ -80,8 +80,6 @@ brooklyn.catalog:
             uniqueTag: etcd-endpoint-joiner
             enricher.sourceSensor: $brooklyn:sensor("etcd.endpoint.list")
             enricher.targetSensor: $brooklyn:sensor("etcd.endpoint")
-            enricher.joiner.minimum: 1
-            enricher.joiner.maximum: 1
             enricher.joiner.quote: false
         - type: org.apache.brooklyn.enricher.stock.Transformer
           brooklyn.config:
@@ -92,3 +90,4 @@ brooklyn.catalog:
               $brooklyn:formatString:
               - "etcd://%s"
               - $brooklyn:attributeWhenReady("etcd.endpoint")
+

--- a/catalog.bom
+++ b/catalog.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: 2.0.0
+  version: 2.1.0
   iconUrl: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-glyph-color.png
   description: |
     Etcd is an open-source distributed key-value store that serves as 
@@ -12,7 +12,7 @@ brooklyn.catalog:
     qa: catalog.tests.bom
 
   brooklyn.libraries:
-  - https://oss.sonatype.org/content/repositories/releases/io/brooklyn/etcd/brooklyn-etcd/2.0.0/brooklyn-etcd-2.0.0.jar
+  - https://oss.sonatype.org/content/repositories/releases/io/brooklyn/etcd/brooklyn-etcd/2.1.0/brooklyn-etcd-2.1.0.jar
 
   items:
   - id: etcd-cluster-template

--- a/catalog.tests.bom
+++ b/catalog.tests.bom
@@ -99,71 +99,30 @@ brooklyn.catalog:
           assert:
           - matches: running
         - type: org.apache.brooklyn.test.framework.TestSensor
-          name: TEST [size] IS [2]
+          name: TEST [size] IS [4]
           target: $brooklyn:component("etcd")
           sensor: group.members.count
           assert:
           - equals: 4
-
-
-
-  ##
-  # Tests an etcd cluster with load balancing
-  #
-  # TODO: Does not assert that members are connected correctly, e.g. that data written to one
-  #       member can be read from another.
-  # TODO: Does not check that the members are all reachable.
-  ##
-  - id: etcd-cluster-load-balanced-test
-    name: Etcd cluster tests
-    item:
-      brooklyn.parameters:
-      - name: timeout.initialStartup
-        description: |
-          The timeout for provisioning, installing and launching the app-under-test.
-        type: org.apache.brooklyn.util.time.Duration
-        default: 20m
-      - name: timeout.runtimeAssertion
-        type: org.apache.brooklyn.util.time.Duration
-        description: |
-          The timeout for any other operation (e.g. invoking an effector or
-          waiting for a sensor to be updated)
-        default: 5m
-      services:
-      - type: etcd-cluster-loadbalanced
-        id: etcd
-        brooklyn.config:
-          etcd.initial.size: 3
-      - type: org.apache.brooklyn.test.framework.TestCase
-        brooklyn.config:
-          timeout: $brooklyn:scopeRoot().config("timeout.runtimeAssertion")
-          targetId: etcd
-        name: Tests
-        brooklyn.children:
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: TEST [service.state] IS [running]
+        - type: org.apache.brooklyn.test.framework.TestSshCommand
+          name: TEST ssh put data
+          target: $brooklyn:entity("etcd-node")
+          command:
+            $brooklyn:formatString:
+            - "%s/etcdctl set /message Hello"
+            - $brooklyn:entity("etcd-node").attributeWhenReady("expandedinstall.dir")
+          assertStatus:
+            equals: 0
+        - type: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
           target: $brooklyn:component("etcd")
-          sensor: service.state
-          timeout: $brooklyn:scopeRoot().config("timeout.initialStartup")
-          assert:
-          - matches: running
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: TEST [service.state] IS [running]
-          target: $brooklyn:component("etcd")
-          sensor: service.state
-          assert:
-          - matches: running
-        - type: org.apache.brooklyn.test.framework.TestSensor
-          name: TEST [size] IS [3]
-          target: $brooklyn:component("etcd")
-          sensor: group.members.count
-          assert:
-          - equals: 3
-#        - type: org.apache.brooklyn.test.framework.TestSshCommand
-#          name: TEST ssh put data
-#          command:
-#            $brooklyn:formatString:
-#            - curl -L -X PUT %s/v2/keys/message -d value="Hello"
-#            - $brooklyn:component("nginx").attributeWhenReady("main.uri")
-#          assertStatus:
-#            equals: 0
+          testSpec:
+            $brooklyn:entitySpec:
+              type: org.apache.brooklyn.test.framework.TestSshCommand
+              name: TEST ssh get data
+              target: $brooklyn:entity("etcd-node")
+              command:
+                $brooklyn:formatString:
+                - "%s/etcdctl get /message"
+                - $brooklyn:entity("etcd-node").attributeWhenReady("expandedinstall.dir")
+              assertOut:
+                equals: "Hello"

--- a/catalog.tests.bom
+++ b/catalog.tests.bom
@@ -78,7 +78,7 @@ brooklyn.catalog:
       - type: etcd-cluster
         id: etcd
         brooklyn.config:
-          cluster.initial.size: 2
+          cluster.initial.size: 4
       - type: org.apache.brooklyn.test.framework.TestCase
         brooklyn.config:
           timeout: $brooklyn:scopeRoot().config("timeout.runtimeAssertion")
@@ -97,10 +97,73 @@ brooklyn.catalog:
           target: $brooklyn:component("etcd")
           sensor: service.state
           assert:
-          - equals: running
+          - matches: running
         - type: org.apache.brooklyn.test.framework.TestSensor
           name: TEST [size] IS [2]
           target: $brooklyn:component("etcd")
           sensor: group.members.count
           assert:
-          - equals: 2
+          - equals: 4
+
+
+
+  ##
+  # Tests an etcd cluster with load balancing
+  #
+  # TODO: Does not assert that members are connected correctly, e.g. that data written to one
+  #       member can be read from another.
+  # TODO: Does not check that the members are all reachable.
+  ##
+  - id: etcd-cluster-load-balanced-test
+    name: Etcd cluster tests
+    item:
+      brooklyn.parameters:
+      - name: timeout.initialStartup
+        description: |
+          The timeout for provisioning, installing and launching the app-under-test.
+        type: org.apache.brooklyn.util.time.Duration
+        default: 20m
+      - name: timeout.runtimeAssertion
+        type: org.apache.brooklyn.util.time.Duration
+        description: |
+          The timeout for any other operation (e.g. invoking an effector or
+          waiting for a sensor to be updated)
+        default: 5m
+      services:
+      - type: etcd-cluster-loadbalanced
+        id: etcd
+        brooklyn.config:
+          etcd.initial.size: 3
+      - type: org.apache.brooklyn.test.framework.TestCase
+        brooklyn.config:
+          timeout: $brooklyn:scopeRoot().config("timeout.runtimeAssertion")
+          targetId: etcd
+        name: Tests
+        brooklyn.children:
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: TEST [service.state] IS [running]
+          target: $brooklyn:component("etcd")
+          sensor: service.state
+          timeout: $brooklyn:scopeRoot().config("timeout.initialStartup")
+          assert:
+          - matches: running
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: TEST [service.state] IS [running]
+          target: $brooklyn:component("etcd")
+          sensor: service.state
+          assert:
+          - matches: running
+        - type: org.apache.brooklyn.test.framework.TestSensor
+          name: TEST [size] IS [3]
+          target: $brooklyn:component("etcd")
+          sensor: group.members.count
+          assert:
+          - equals: 3
+#        - type: org.apache.brooklyn.test.framework.TestSshCommand
+#          name: TEST ssh put data
+#          command:
+#            $brooklyn:formatString:
+#            - curl -L -X PUT %s/v2/keys/message -d value="Hello"
+#            - $brooklyn:component("nginx").attributeWhenReady("main.uri")
+#          assertStatus:
+#            equals: 0

--- a/catalog.tests.bom
+++ b/catalog.tests.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: 2.0.0
+  version: 2.1.0
   itemType: template
   license_code: APACHE-2.0
   license_url: http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
+++ b/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdClusterImpl.java
@@ -137,6 +137,8 @@ public class EtcdClusterImpl extends DynamicClusterImpl implements EtcdCluster {
                     log.info("Adding first node {}: {}; {} to cluster", new Object[] { this, member, name });
                     ((EntityInternal) member).sensors().set(EtcdNode.ETCD_NODE_HAS_JOINED_CLUSTER, Boolean.TRUE);
                 } else {
+                    // Bit of a hack but if we add a nodes too quickly the etcd cluster falls over
+                    Time.sleep(Duration.seconds(5));
                     int retry = 3; // TODO use a configurable Repeater instead?
                     while (retry --> 0 && member.sensors().get(EtcdNode.ETCD_NODE_HAS_JOINED_CLUSTER) == null && !nodes.containsKey(member)) {
                         Optional<Entity> anyNodeInCluster = Iterables.tryFind(nodes.keySet(), Predicates.and(


### PR DESCRIPTION
The etcd,authority sensor will now list all etcd endpoints as the etcd client can then do load balancing.
Added tests that set an item on one node and check its availability from all other nodes
Added a pause between adding nodes to the cluster as occasionally the cluster was failing to come up when these happened simultaneously.
