### PR TITLE
Use the external address so that TLS works on SL etc.

### DIFF
--- a/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdNodeSshDriver.java
+++ b/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdNodeSshDriver.java
@@ -165,7 +165,7 @@ public class EtcdNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
     /** @deprecated since 2.1.0. Use {@link #getAdvertiseClientUrls()} instead. */
     @Deprecated
     protected String getClientUrl() {
-        return String.format("%s://%s:%d", getClientProtocol(), getSubnetAddress(), getClientPort());
+        return String.format("%s://%s:%d", getClientProtocol(), getAddress(), getClientPort());
     }
 
     /** @deprecated since 2.1.0. Use {@link #getAdvertisePeerUrls()} instead. */


### PR DESCRIPTION
When the etcd is deployed onto a cloud and the external and subnet addresses are different, clients can't connect to etcd as the certificate is defined for the external address only.   This commit changes things to use the host address for endpoints for etcd, which lets the TLS connection be established.
