### PR TITLE
Add top level catalog.bom with libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # Brooklyn Etcd Entities
 
 Entities for a CoreOS etcd key-value store cluster
+
+
+### [For contributors] Release Process
+
+#### Snapshot Release
+
+In order to release a new snapshot version to Sonatype:
+
+    mvn source:jar javadoc:jar deploy -DdeployTo=sonatype
+
+
+#### Official Relesae
+
+1. Create a new branch, e.g. `release/2.3.0`, and checkout that branch
+
+2. Update the version running the command below (and double-check that pom.xml was correctly updated):
+
+    GA_VERSION=2.3.0
+    ~/repos/brooklyn/brooklyn-dist/release/change-version.sh BROOKLYN_ETCD ${GA_VERSION}-SNAPSHOT ${GA_VERSION}
+
+3. Update the expected download URL in catalog.bom (note the `r=releases` and the correct version), e.g. to
+
+    https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.2.1
+
+4. Confirm it builds: `mvn clean install`
+
+5. Push release to sonatype, following the normal Sonatype process. See 
+   [Very Old Brooklyn Instructions](https://github.com/brooklyncentral/brooklyn/blob/0.7.0-M1/docs/dev/tips/release.md)
+   from the days before it was an Apache project, when we were deploying to Sonatype.
+
+    mvn source:jar javadoc:jar -DdeployTo=sonatype
+

--- a/catalog.bom
+++ b/catalog.bom
@@ -1,0 +1,17 @@
+brooklyn.catalog:
+  version: "2.3.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  iconUrl: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-glyph-color.png
+  description: |
+    CoreOS etcd is an open-source distributed key-value store that serves as
+    the backbone of distributed systems by providing a canonical hub for
+    cluster coordination and state management.
+  publish:
+    license_code: APACHE-2.0
+    license_url: http://www.apache.org/licenses/LICENSE-2.0.txt
+    overview: README.md
+
+  brooklyn.libraries:
+    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.3.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+
+  items:
+    - classpath://io.brooklyn.etcd.brooklyn-etcd:brooklyn-etcd/catalog.bom

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
                     <includes>
                       <include>*.bom</include>
                       <include>examples/*.*</include>
+                      <exclude>catalog.bom</exclude>
                     </includes>
                   </resource>
                 </resources>

--- a/src/main/resources/catalog.bom
+++ b/src/main/resources/catalog.bom
@@ -1,3 +1,0 @@
-brooklyn.catalog:
-  items:
-    - classpath://io.brooklyn.etcd.brooklyn-etcd:brooklyn-etcd/catalog.bom


### PR DESCRIPTION
Can load either using `catalog.bom` which gets Jar from sonatype, or include Jar as dependency and load using classpath reference to `brooklyn-etcd/catalog.bom`
