### PR TITLE
Change version to 2.4.0-SNAPSHOT

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.3.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-glyph-color.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as
@@ -11,7 +11,7 @@ brooklyn.catalog:
     overview: README.md
 
   brooklyn.libraries:
-    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.3.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
 
   items:
     - classpath://io.brooklyn.etcd.brooklyn-etcd:brooklyn-etcd/catalog.bom

--- a/etcd.bom
+++ b/etcd.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.3.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-glyph-color.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.brooklyn.etcd</groupId>
     <artifactId>brooklyn-etcd</artifactId>
-    <version>2.3.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
+    <version>2.4.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
     <packaging>jar</packaging>
     <name>Brooklyn Etcd Entities</name>
     <description>

--- a/tests/etcd.tests.bom
+++ b/tests/etcd.tests.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.3.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-glyph-color.png
   license_code: APACHE-2.0
   license_url: http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
Now that we've switched master to brooklyn 0.11.0-SNAPSHOT, we also need to bump the brooklyn-etcd version number.

I'll also create a `2.3.x` branch, which we'll release 2.3.0 from (once brooklyn 0.10.0 is released).