### PR TITLE
Version 2.5.0-SNAPSHOT

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as
@@ -11,7 +11,7 @@ brooklyn.catalog:
     overview: README.md
 
   brooklyn.libraries:
-    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
 
   items:
     - classpath://io.brooklyn.etcd.brooklyn-etcd:etcd/catalog.bom

--- a/catalog/etcd/etcd.bom
+++ b/catalog/etcd/etcd.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.brooklyn.etcd</groupId>
     <artifactId>brooklyn-etcd</artifactId>
-    <version>2.4.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
+    <version>2.5.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
     <packaging>bundle</packaging>
     <name>Brooklyn Etcd Entities</name>
     <description>

--- a/tests/etcd/etcd.tests.bom
+++ b/tests/etcd/etcd.tests.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.4.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
   license_code: APACHE-2.0
   license_url: http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
Updated version after making [2.4.0](https://github.com/brooklyncentral/brooklyn-etcd/releases/tag/v2.4.0) release