### PR TITLE
Change version to 2.6.0-SNAPSHOT

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as
@@ -11,7 +11,7 @@ brooklyn.catalog:
     overview: README.md
 
   brooklyn.libraries:
-    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
 
   items:
     - classpath://io.brooklyn.etcd.brooklyn-etcd:etcd/catalog.bom

--- a/catalog.bom
+++ b/catalog.bom
@@ -10,8 +10,5 @@ brooklyn.catalog:
     license_url: http://www.apache.org/licenses/LICENSE-2.0.txt
     overview: README.md
 
-  brooklyn.libraries:
-    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
-
   items:
-    - classpath://io.brooklyn.etcd.brooklyn-etcd:etcd/catalog.bom
+    - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn.etcd&a=brooklyn-etcd&v=2.6.0-SNAPSHOT&p=bom&c=etcd"  # BROOKLYN_ETCD_VERSION

--- a/catalog/etcd/catalog.bom
+++ b/catalog/etcd/catalog.bom
@@ -1,4 +1,5 @@
 brooklyn.catalog:
+  version: "2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   items:
     - classpath://io.brooklyn.etcd.brooklyn-etcd:etcd/etcd.bom
 
@@ -19,7 +20,7 @@ brooklyn.catalog:
                 description: |
                   The version of etcd to install
                 type: string
-                default: "2.3.1"
+                default: "3.2.7"
               - name: etcd.client.port
                 label: Etcd Client Port
                 description: |

--- a/catalog/etcd/etcd.bom
+++ b/catalog/etcd/etcd.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as
@@ -29,7 +29,7 @@ brooklyn.catalog:
             description: |
               The version of etcd to install
             type: string
-            default: "2.3.1"
+            default: "3.2.7"
           - name: etcd.client.port
             label: Etcd Client Port
             description: |

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.brooklyn.etcd</groupId>
     <artifactId>brooklyn-etcd</artifactId>
-    <version>2.5.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
+    <version>2.6.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
     <packaging>bundle</packaging>
     <name>Brooklyn Etcd Entities</name>
     <description>

--- a/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdNode.java
+++ b/src/main/java/io/brooklyn/entity/nosql/etcd/EtcdNode.java
@@ -38,7 +38,7 @@ import org.apache.brooklyn.util.time.Duration;
 public interface EtcdNode extends SoftwareProcess {
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.3.1");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "3.2.7");
 
     @SetFromFlag("startTimeout")
     ConfigKey<Duration> START_TIMEOUT = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.START_TIMEOUT, Duration.minutes(10));
@@ -67,7 +67,7 @@ public interface EtcdNode extends SoftwareProcess {
     /** @since 2.1.0 */
     @SetFromFlag("etcdSecurePeer")
     ConfigKey<Boolean> SECURE_CLIENT = ConfigKeys.newBooleanConfigKey("etcd.client.secure");
- 
+
     /** @since 2.2.1 */
     AttributeSensor<String> CLIENT_SCHEME = Sensors.newStringSensor("etcd.client.scheme", "The scheme for the client URL");
 
@@ -84,7 +84,7 @@ public interface EtcdNode extends SoftwareProcess {
 
     AttributeSensor<Boolean> ETCD_NODE_HAS_JOINED_CLUSTER = Sensors.newBooleanSensor(
             "etcd.node.nodeHasJoinedCluster", "Flag to indicate whether the etcd node has joined a cluster member");
- 
+
     MethodEffector<Void> JOIN_ETCD_CLUSTER = new MethodEffector<Void>(EtcdNode.class, "joinCluster");
     MethodEffector<Void> LEAVE_ETCD_CLUSTER = new MethodEffector<Void>(EtcdNode.class, "leaveCluster");
 

--- a/tests/etcd/etcd.tests.bom
+++ b/tests/etcd/etcd.tests.bom
@@ -2,7 +2,7 @@ brooklyn.catalog:
   items:
   - "https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.tests.bom"
   - id: etcd-cluster-tests
-    version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+    version: "2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
     iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
     name: "Etcd cluster and single node tests"
     license_code: APACHE-2.0
@@ -54,7 +54,7 @@ brooklyn.catalog:
                   matches: "Hello"
 
       - type: test-case
-        name: "Etc cluster tests"
+        name: "Etcd cluster tests"
         brooklyn.children:
 
         - type: etcd-cluster


### PR DESCRIPTION
- bump etcd version to 3.2.7

---


@aledsage @grkvlt can you please have a look at it? When I import the catalog.bom into my server I can see the following summary which looks wrong as it references some items with version 2.5.0

<img width="394" alt="screen shot 2017-09-14 at 9 49 00 pm" src="https://user-images.githubusercontent.com/222887/30452628-ab88626e-9996-11e7-94e7-37f18390662c.png">


