### PR TITLE
Bump to 2.6.0-snapshot

### DIFF
--- a/catalog/catalog.bom
+++ b/catalog/catalog.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as

--- a/catalog/etcd/etcd.bom
+++ b/catalog/etcd/etcd.bom
@@ -1,5 +1,5 @@
 brooklyn.catalog:
-  version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+  version: "2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
   iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
   description: |
     CoreOS etcd is an open-source distributed key-value store that serves as

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.brooklyn.etcd</groupId>
     <artifactId>brooklyn-etcd</artifactId>
-    <version>2.5.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
+    <version>2.6.0-SNAPSHOT</version> <!-- BROOKLYN_ETCD_VERSION -->
     <packaging>bundle</packaging>
     <name>Brooklyn Etcd Entities</name>
     <description>

--- a/tests/etcd/etcd.tests.bom
+++ b/tests/etcd/etcd.tests.bom
@@ -2,7 +2,7 @@ brooklyn.catalog:
   items:
   - "https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.tests.bom"
   - id: etcd-cluster-tests
-    version: "2.5.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
+    version: "2.6.0-SNAPSHOT" # BROOKLYN_ETCD_VERSION
     iconUrl: classpath://io.brooklyn.etcd.brooklyn-etcd:icons/etcd.png
     name: "Etcd cluster and single node tests"
     license_code: APACHE-2.0


### PR DESCRIPTION
Please first merge https://github.com/brooklyncentral/brooklyn-etcd/pull/21 (so that 2.5.0-snapshot can depend on brooklyn 0.12.0).