### PR TITLE
Fix rebind / classloading of catalog

### DIFF
--- a/catalog/etcd/catalog.bom
+++ b/catalog/etcd/catalog.bom
@@ -1,3 +1,3 @@
 brooklyn.catalog:
   items:
-    - classpath://io.brooklyn.etcd.brooklyn-etcd:etcd/etcd.bom
+    - classpath://etcd/etcd.bom


### PR DESCRIPTION
If have two etcd bundles installed in Brooklyn, they both use the 
most recent one for `etcd/etcd.bom` because the classpath includes
the bundle name. It should instead load it from the current bundle.