### PR TITLE
Specifies version of maven-deploy-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     </properties>
 
     <scm>
@@ -117,6 +118,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <!-- Following the release of v 3.0.0-M1 of the deploy plug, the bundle
+                         was failing to deploy to artifactory with "401 unauthorized". The underlying
+                         problem may be as follows: https://issues.apache.org/jira/projects/MDEPLOY/issues/MDEPLOY-244 -->
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Without the version specified, the artifact was failing to upload to artifactory when deploying